### PR TITLE
chore: update bracketSameLine option

### DIFF
--- a/prettier.json
+++ b/prettier.json
@@ -3,7 +3,7 @@
   "semi": false,
   "singleQuote": true,
   "tabWidth": 2,
-  "jsxBracketSameLine": true,
+  "bracketSameLine": true,
   "htmlWhitespaceSensitivity": "ignore",
   "trailingComma": "none",
   "arrowParens": "avoid"


### PR DESCRIPTION
jsxBracketSameLine is now [deprecated](https://prettier.io/docs/en/options.html#deprecated-jsx-brackets)